### PR TITLE
Big feature dump - claiming matches from the app

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,33 +3,12 @@ Browser-based tool for gurus to edit result sheets for 3 Card Blind MTG matches 
 
 Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.
 
-## Working Effectively
-- **Setup and serve the application:**
-  - `cd` to repository root
-  - `python3 -m http.server 8000` -- starts in 1 second. NEVER CANCEL. Navigate to http://localhost:8000
-  - Alternative: `npx serve -l 3000` -- starts in 2 seconds. NEVER CANCEL. Navigate to http://localhost:3000
-- **Validate JavaScript syntax:**
-  - `node -c js/main.js` -- validates main entry point syntax (instant)
-  - `for f in $(find js -name "*.js"); do node -c "$f"; done` -- validates all JS files (takes 2-3 seconds)
-
 ## Application Architecture
 - **Pure client-side application** - no build process, no server dependencies
 - **Technology stack**: HTML5, CSS3, ES6 JavaScript modules
 - **External APIs**: Google Sheets API, Google OAuth, Scryfall API (MTG card images)
 - **Data persistence**: Google Sheets + browser localStorage
 - **Authentication**: Google OAuth 2.0
-
-## Validation
-- **ALWAYS manually test any changes** by serving the application and verifying it loads correctly
-- **User scenario validation**: After making changes, ALWAYS test:
-  1. Open the application in browser (http://localhost:8000 or :3000)
-  2. Verify the header "3CB Visual Guru" displays correctly
-  3. Check browser console for JavaScript errors (F12 → Console)
-  4. If modifying authentication: Test that sign-in interface appears
-  5. If modifying UI: Take screenshots to verify visual changes
-- **NEVER CANCEL** any server commands - they start quickly (1-2 seconds) and run continuously
-- **JavaScript validation**: Always run `node -c` on modified JavaScript files before committing
-- **Full application test**: Always serve and load the application after any changes to verify functionality
 
 ## Common Tasks
 
@@ -69,25 +48,23 @@ Always reference these instructions first and fallback to search or bash command
 - **styles/main.css**: All CSS styling for the application
 
 ### Development Environment
-- **Required tools**: Python 3.12.3, Node.js v20.19.4, modern web browser
+- **Required tools**: Node.js v20.19.4, modern web browser
 - **No build tools required**: Application uses native ES6 modules
 - **No package installation**: All dependencies loaded from CDN
 - **Linting**: Use `node -c` for syntax validation (no ESLint configuration present)
+
+### Code changes workflow
+1. **Do the changes requested**: Ensure the changes are necessary and align with the application's purpose.
+2. **Check this document (copilot-instructions.md)**: If the changes require updates to this document, particularly the Repository Structure, make them as well.
+3. **Check the README.md**: Ensure the README reflects any changes made to the application or its usage.
+4. **Commit your changes**: Use clear commit messages that describe the changes made.
 
 ### Working with the Codebase
 - **Entry point**: Always start by examining `index.html` and `js/main.js`
 - **Module system**: Uses ES6 import/export - follow import chains to understand dependencies
 - **Event handling**: Centralized in `js/modules/uiController.js`
 - **API integration**: Google Sheets API in `googleSheetsAPI.js`, Scryfall API in `scryfallAPI.js`
-- **State management**: Distributed across modules, localStorage for persistence
-
-### Testing Changes
-1. **Serve the application**: `python3 -m http.server 8000` or `npx serve -l 3000`
-2. **Open in browser**: Navigate to http://localhost:8000 (or :3000)
-3. **Check console**: Open browser DevTools (F12) → Console tab for errors
-4. **Verify loading**: Application should show "3CB Visual Guru" header immediately
-5. **Note**: Google APIs may show errors in test environments - this is expected
-6. **Screenshot changes**: Always take screenshots of UI modifications
+- **State management**: Distributed across modules, Google appData for persistence
 
 ### Troubleshooting
 - **Application not loading**: Check browser console for JavaScript errors
@@ -99,19 +76,6 @@ Always reference these instructions first and fallback to search or bash command
 - **Server not accessible**: Ensure firewall allows local connections on chosen port
 - **Syntax errors**: Run `node -c <filename>` to validate JavaScript syntax
 
-### Performance Notes
-- **Server startup**: Python HTTP server: ~1 second, npx serve: ~2 seconds
-- **JavaScript validation**: All files: ~0.5 seconds total (12 files)
-- **Application loading**: Instant for static content, Google APIs may take 3-5 seconds
-- **File serving**: Static files serve instantly once server is running
-
-### Expected Timings (for timeout reference)
-- Python HTTP server startup: 1 second (NEVER CANCEL - set timeout 60+ seconds)
-- npx serve startup: 2 seconds (NEVER CANCEL - set timeout 60+ seconds)  
-- JavaScript syntax validation: 0.5 seconds for all files
-- npm scripts (dev/build/test): Instant (< 0.1 seconds)
-- Application loading in browser: 1-2 seconds for UI, Google API errors expected
-
 ### File Access Patterns
 - **Static files**: Direct HTTP access for HTML, CSS, JS
 - **ES6 modules**: Browser handles module loading automatically
@@ -119,30 +83,5 @@ Always reference these instructions first and fallback to search or bash command
 - **No compilation**: Files served directly as written
 
 ## Validation Scenarios
-After making any changes, ALWAYS test these scenarios:
 
-1. **Basic Loading**: 
-   - Start server: `python3 -m http.server 8000`
-   - Open http://localhost:8000
-   - Verify header displays: "3CB Visual Guru"
-   - Check browser console has no critical JavaScript errors
-
-2. **Module Loading**:
-   - Open browser DevTools → Network tab
-   - Refresh page
-   - Verify all JS modules load successfully (200 status)
-   - Check Console for import/export errors
-
-3. **JavaScript Syntax**:
-   - Run: `for f in $(find js -name "*.js"); do echo "Checking $f"; node -c "$f" || echo "✗ $f failed"; done`
-   - All files should pass syntax check silently
-   - Takes ~0.5 seconds total for all 12 JavaScript files
-
-4. **UI Responsiveness**:
-   - Test on different browser window sizes
-   - Verify mobile viewport scaling works
-   - Take screenshots of any visual changes
-
-**Expected Console Messages**: In test environments, you will see Google API errors like "ERR_BLOCKED_BY_CLIENT" and "gapi is not defined" - these are NORMAL and expected. Focus on verifying the application structure loads (header displays correctly).
-
-Always include these validation steps in your development workflow. The application is designed to be simple and fast to validate - NEVER skip validation because it is quick and essential.
+**Expected Console Messages**: In test environments, you will see Google API errors like "ERR_BLOCKED_BY_CLIENT" and "gapi is not defined" - these are NORMAL and expected.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,10 @@ Browser-based tool for gurus to edit result sheets for 3 Card Blind MTG matches 
 
 Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.
 
+## Application Logic
+3 Card Blind matches consist of two players, each with a deck of 3 cards. The result of the match is determined by human "gurus" who analyse the match and score it as Win/Tie/Loss. Three gurus analyse each match and an agreement must be reached on the final outcome. The three gurus take the roles of Red, Blue, and Green, each analyzing the match from their perspective. The possible results that each guru can pick from are Win, Tie, and Loss.
+Before scoring a match the guru must claim it by entering their guru signature. This tells other gurus with the same color that this match is being analysed. Gurus can analyse only matches that they have claimed with their signature.
+
 ## Application Architecture
 - **Pure client-side application** - no build process, no server dependencies
 - **Technology stack**: HTML5, CSS3, ES6 JavaScript modules

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ Browser-based tool for gurus to edit result sheets for 3 Card Blind MTG matches 
 Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.
 
 ## Application Logic
-3 Card Blind matches consist of two players, each with a deck of 3 cards. The result of the match is determined by human "gurus" who analyse the match and score it as Win/Tie/Loss. Three gurus analyse each match and an agreement must be reached on the final outcome. The three gurus take the roles of Red, Blue, and Green, each analyzing the match from their perspective. The possible results that each guru can pick from are Win, Tie, and Loss.
+3 Card Blind matches consist of two players, each with a deck of 3 cards. The result of the match is determined by human "gurus" who analyse the match and score it as Win/Tie/Loss. Three gurus analyse each match and an agreement must be reached on the final outcome. The three gurus take the roles of Red, Blue, and Green, each analysing the match from their perspective. The possible results that each guru can pick from are Win, Tie, and Loss.
 Before scoring a match the guru must claim it by entering their guru signature. This tells other gurus with the same color that this match is being analysed. Gurus can analyse only matches that they have claimed with their signature.
 
 ## Application Architecture

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and continue guruing!
 - The app will load and parse the pod data
 - Only matches assigned to your guru signature will be displayed
 
-### 4. **Analyze Matches**
+### 4. **Analyse Matches**
 - View card images for both players
 - Use Win/Tie/Loss buttons to score matches
 - Navigate between matches with Previous/Next buttons

--- a/index.html
+++ b/index.html
@@ -158,7 +158,23 @@
                                     <h2 id="sheet-title">Match Results Editor</h2>
                                     <div class="analysis-progress">
                                         <span id="current-row-info">Row 1 of 0</span>
-                                        <span id="sheet-name-info">Processing sheet...</span>
+                                        <div class="guru-color-selector">
+                                            <span id="sheet-name-info" class="guru-color-trigger">Processing sheet...</span>
+                                            <div id="guru-color-dropdown" class="guru-color-dropdown">
+                                                <div class="guru-color-option" data-color="red">
+                                                    <div class="guru-color-indicator red"></div>
+                                                    <span>Red Guru</span>
+                                                </div>
+                                                <div class="guru-color-option" data-color="blue">
+                                                    <div class="guru-color-indicator blue"></div>
+                                                    <span>Blue Guru</span>
+                                                </div>
+                                                <div class="guru-color-option" data-color="green">
+                                                    <div class="guru-color-indicator green"></div>
+                                                    <span>Green Guru</span>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                                 <div class="editor-controls">

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
                                     </button>
                                 </div>
                                 
-                                <button id="skip-btn" class="secondary-btn" disabled>Skip</button>
+                                <button id="skip-btn" class="secondary-btn" disabled>Next</button>
                             </div>
                             
                             <div class="editor-header">

--- a/index.html
+++ b/index.html
@@ -151,6 +151,7 @@
                                 </div>
                                 
                                 <button id="skip-btn" class="secondary-btn">Next</button>
+                                <button id="discrepancy-btn" class="secondary-btn discrepancy-btn">Next Discrepancy</button>
                             </div>
                             
                             <div class="editor-header">
@@ -181,12 +182,6 @@
                                     <button id="refresh-btn" class="secondary-btn">Refresh</button>
                                     <button id="exit-analysis-btn" class="secondary-btn">Exit</button>
                                 </div>
-                            </div>
-                            
-                            <div class="completion-message" id="completion-message" style="display: none;">
-                                <h3>Analysis Complete!</h3>
-                                <p>You have analyzed all rows for your guru signature.</p>
-                                <button id="restart-analysis-btn" class="primary-btn">Refresh</button>
                             </div>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
                                     </button>
                                 </div>
                                 
-                                <button id="skip-btn" class="secondary-btn" disabled>Next</button>
+                                <button id="skip-btn" class="secondary-btn">Next</button>
                             </div>
                             
                             <div class="editor-header">

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
         </div>
 
         <main id="main-content">
+            <div class="status-message" id="status-message"></div>
             <div class="login-section" id="login-section" style="display: none;">
                 <h2>Authentication Required</h2>
                 <p>Please log in with your Google account to edit pod sheets.</p>
@@ -82,7 +83,6 @@
                         <input type="url" id="sheet-url" placeholder="https://docs.google.com/spreadsheets/d/..." />
                         <button id="load-sheet-btn" class="primary-btn">Load Pod</button>
                     </div>
-                    <div class="status-message" id="status-message"></div>
                 </section>
 
                 <section class="sheet-editor-section fullscreen-analysis" id="sheet-editor" style="display: none;">

--- a/js/main.js
+++ b/js/main.js
@@ -257,8 +257,7 @@ class ThreeCardBlindGuruTool {
             this.uiController.setLoadingState(true);
 
             const sheetId = this.extractSheetId(url);
-            const guruSignature = this.guruSignature.getSignature();
-            const sheetData = await this.sheetsAPI.getSheetData(sheetId, guruSignature);
+            const sheetData = await this.sheetsAPI.getSheetData(sheetId);
             
             this.currentSheetData = sheetData;
             this.currentSheetId = sheetId;
@@ -270,13 +269,9 @@ class ThreeCardBlindGuruTool {
             // Add to recent pods
             this.recentPodsManager.addRecentPod(sheetId, sheetData.title || 'Untitled Pod', url);
             
-            // Show filtering info
-            if (guruSignature && sheetData.sheets) {
-                const totalRows = this.analysisInterface.getTotalRows();
-                this.uiController.showStatus(`Found ${totalRows} rows to analyze for guru "${guruSignature}"`, 'success');
-            } else {
-                this.uiController.showStatus('Pod loaded successfully!', 'success');
-            }
+            // Show success message
+            const totalRows = this.analysisInterface.getTotalRows();
+            this.uiController.showStatus(`Pod loaded successfully - ${totalRows} rows available`, 'success');
             
         } catch (error) {
             console.error('Error loading pod:', error);
@@ -295,15 +290,14 @@ class ThreeCardBlindGuruTool {
         try {
             this.uiController.showStatus('Refreshing pod...', 'loading');
             
-            const guruSignature = this.guruSignature.getSignature();
-            const sheetData = await this.sheetsAPI.getSheetData(this.currentSheetId, guruSignature);
+            const sheetData = await this.sheetsAPI.getSheetData(this.currentSheetId);
             this.currentSheetData = sheetData;
             
             // Reload data into the analysis interface
             await this.analysisInterface.loadData(sheetData);
             
             const totalRows = this.analysisInterface.getTotalRows();
-            this.uiController.showStatus(`Refreshed - ${totalRows} rows to analyze`, 'success');
+            this.uiController.showStatus(`Refreshed - ${totalRows} rows available`, 'success');
             
         } catch (error) {
             console.error('Error refreshing pod:', error);

--- a/js/main.js
+++ b/js/main.js
@@ -218,11 +218,6 @@ class ThreeCardBlindGuruTool {
             // The loadSheet() method will be called automatically by the recent pods manager
         });
 
-        // Listen for refresh analysis events from the analysis interface
-        window.addEventListener('refreshAnalysis', () => {
-            this.refreshSheet();
-        });
-
         // Listen for user logout to optionally handle recent pods
         window.addEventListener('userLoggedOut', () => {
             // Note: We keep recent pods even after logout so they're available when user logs back in
@@ -313,7 +308,7 @@ class ThreeCardBlindGuruTool {
         
         // Show the sheet input section again
         this.uiController.showSheetInputSection();
-        this.uiController.showStatus('Analysis session ended. Load a sheet to start analyzing again.', 'info');
+        this.uiController.showStatus('Analysis session ended. Load a sheet to start analysing again.', 'info');
     }
 
     isValidGoogleSheetsUrl(url) {

--- a/js/modules/guruAnalysisInterface.js
+++ b/js/modules/guruAnalysisInterface.js
@@ -1661,7 +1661,7 @@ export class GuruAnalysisInterface {
         colorSelectionContainer.innerHTML = `
             <div class="color-selection-screen">
                 <h3>Choose Your Guru Color</h3>
-                <h4 class="sheet-title">Sheet: ${sheetTitle}</h4>
+                <h4 class="sheet-title">Pod: ${sheetTitle}</h4>
                 <p>Your signature was not found in any existing analysis. Please select which guru color you want to use for analysis:</p>
                 
                 <div class="color-options">

--- a/js/modules/guruAnalysisInterface.js
+++ b/js/modules/guruAnalysisInterface.js
@@ -2048,6 +2048,14 @@ export class GuruAnalysisInterface {
                 this.closeMatchTableModal();
             }
         });
+
+        // Auto-scroll to the current match row
+        requestAnimationFrame(() => {
+            const currentRow = table.querySelector('tr.current-row');
+            if (currentRow) {
+                currentRow.scrollIntoView({ block: 'center', behavior: 'auto' });
+            }
+        });
     }
 
     closeMatchTableModal() {

--- a/js/modules/guruAnalysisInterface.js
+++ b/js/modules/guruAnalysisInterface.js
@@ -850,11 +850,6 @@ export class GuruAnalysisInterface {
         // Update navigation buttons
         document.getElementById('prev-btn').disabled = this.currentRowIndex === 0;
         document.getElementById('next-btn').disabled = this.currentRowIndex >= this.allRows.length - 1;
-        
-        // Update skip button - disable if there are no more incomplete rows after current
-        const nextIncompleteIndex = this.findFirstEmptyAnalysis(this.currentRowIndex + 1);
-        const hasMoreIncomplete = nextIncompleteIndex !== this.currentRowIndex && nextIncompleteIndex < this.allRows.length;
-        document.getElementById('skip-btn').disabled = !hasMoreIncomplete;
 
         // Hide completion message
         document.getElementById('completion-message').style.display = 'none';

--- a/js/modules/guruAnalysisInterface.js
+++ b/js/modules/guruAnalysisInterface.js
@@ -1210,6 +1210,11 @@ export class GuruAnalysisInterface {
             
             // Update button highlighting immediately based on the new analysis value
             this.highlightCurrentAnalysisButton(value);
+            // Update outcome display
+            const analysisElement = document.getElementById('current-analysis-value');
+            if (analysisElement) {
+                analysisElement.innerHTML = this.buildAnalysisDisplayWithOthers(currentRow, newOutcome);
+            }
             
             this.uiController.showStatus(`Analysis saved: ${this.getAnalysisLabel(value)}`, 'success');
             

--- a/styles/main.css
+++ b/styles/main.css
@@ -606,6 +606,18 @@ section h2, .login-section h2 {
     margin-right: 10px;
 }
 
+/* Inline spinner for buttons */
+.spinner {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border: 2px solid #ffffff40;
+    border-top: 2px solid #ffffff;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-right: 6px;
+}
+
 /* Simple app loading section under header */
 .app-loading {
     display: flex;

--- a/styles/main.css
+++ b/styles/main.css
@@ -399,12 +399,17 @@ section h2, .login-section h2 {
     font-weight: 600;
 }
 
-/* Status message */
+/* Status message, located in the top center */
 .status-message {
     padding: 10px;
     border-radius: 4px;
     margin-top: 10px;
     display: none;
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 9999;
 }
 
 .status-message.success {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1503,3 +1503,126 @@ section h2, .login-section h2 {
         transform: scale(1.02);
     }
 }
+
+/* Color Selection Screen */
+.color-selection-screen {
+    max-width: 600px;
+    margin: 0 auto;
+    text-align: center;
+    padding: 40px 20px;
+}
+
+.color-selection-screen h3 {
+    color: #2c3e50;
+    font-size: 1.8rem;
+    margin-bottom: 16px;
+}
+
+.color-selection-screen p {
+    color: #666;
+    margin-bottom: 30px;
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.color-options {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+.color-option {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    padding: 20px;
+    background: white;
+    border: 2px solid #e9ecef;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+}
+
+.color-option:hover {
+    border-color: #007bff;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+    transform: translateY(-2px);
+}
+
+.color-circle {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.color-circle.red {
+    background: linear-gradient(135deg, #e74c3c, #c0392b);
+}
+
+.color-circle.blue {
+    background: linear-gradient(135deg, #3498db, #2980b9);
+}
+
+.color-circle.green {
+    background: linear-gradient(135deg, #27ae60, #229954);
+}
+
+.color-info {
+    flex: 1;
+    text-align: left;
+}
+
+.color-info h4 {
+    color: #2c3e50;
+    font-size: 1.2rem;
+    margin-bottom: 4px;
+}
+
+.color-info p {
+    color: #666;
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+.select-color-btn {
+    background: #007bff;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 5px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    flex-shrink: 0;
+}
+
+.select-color-btn:hover {
+    background: #0056b3;
+}
+
+.color-selection-note {
+    color: #666;
+    font-size: 0.9rem;
+    font-style: italic;
+    margin: 0;
+}
+
+/* Mobile responsiveness for color selection */
+@media (max-width: 768px) {
+    .color-option {
+        flex-direction: column;
+        text-align: center;
+        gap: 15px;
+    }
+    
+    .color-info {
+        text-align: center;
+    }
+    
+    .select-color-btn {
+        width: 100%;
+    }
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -358,6 +358,14 @@ section h2, .login-section h2 {
     transform: none;
 }
 
+.discrepancy-btn {
+    background-color: #e74c3c;
+    color: white;
+}
+.discrepancy-btn:hover {
+    background-color: #c0392b;
+}
+
 /* Guru Signature Section */
 .guru-signature-section {
     background: white;
@@ -1446,27 +1454,6 @@ section h2, .login-section h2 {
 .navigation-buttons button {
     min-width: 80px;
     flex-shrink: 0;
-}
-
-.completion-message {
-    text-align: center;
-    padding: 40px;
-    background: #d4edda;
-    border: 2px solid #c3e6cb;
-    border-radius: 12px;
-    color: #155724;
-    order: 2;
-}
-
-.completion-message h3 {
-    color: #155724;
-    margin-bottom: 15px;
-    font-size: 1.8rem;
-}
-
-.completion-message p {
-    margin-bottom: 20px;
-    font-size: 1.1rem;
 }
 
 /* Responsive design */

--- a/styles/main.css
+++ b/styles/main.css
@@ -487,10 +487,17 @@ section h2, .login-section h2 {
     outline: none;
 }
 
+
+.guru-color-selector {
+    position: relative;
+    display: inline-block;
+}
+
 .guru-color-dropdown {
+    position: absolute;
     top: 100%;
     left: 0;
-    min-width: 140px;
+    min-width: 160px;
     background: white;
     border: 1px solid #dee2e6;
     border-radius: 6px;
@@ -500,12 +507,14 @@ section h2, .login-section h2 {
     visibility: hidden;
     transform: translateY(-8px);
     transition: all 0.2s ease;
+    pointer-events: none;
 }
 
 .guru-color-dropdown.show {
     opacity: 1;
     visibility: visible;
     transform: translateY(0);
+    pointer-events: auto;
 }
 
 .guru-color-option {
@@ -516,6 +525,9 @@ section h2, .login-section h2 {
     display: flex;
     align-items: center;
     gap: 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .guru-color-option:last-child {
@@ -791,46 +803,56 @@ section h2, .login-section h2 {
     margin-bottom: 0;
 }
 
-/* Navigation controls between players */
+/* Overlay navigation controls in match-details */
+.match-details{
+    position: relative;
+}
+
 .navigation-controls {
+    position: absolute;
+    top: 55%;
+    left: 0;
+    width: 100%;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0 20px;
-    position: relative;
-    height: 60px;
-    flex-shrink: 0;
+    pointer-events: none; /* allow underlying elements to be clickable except buttons */
+    z-index: 2;
+    transform: translateY(-50%);
+    padding: 0 0.5rem;
 }
 
-.nav-arrow-btn {
-    background: #f8f9fa;
-    border: 2px solid #dee2e6;
+.navigation-controls .nav-arrow-btn {
+    pointer-events: auto; /* make buttons clickable */
+    background: rgba(255,255,255,0.85);
     border-radius: 50%;
-    width: 50px;
-    height: 50px;
-    font-size: 28px;
-    font-weight: bold;
-    color: #495057;
-    cursor: pointer;
-    transition: all 0.2s ease;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    font-size: 1.6rem;
+    width: 2.5rem;
+    height: 2.5rem;
     display: flex;
     align-items: center;
     justify-content: center;
+    border: none;
+    transition: background 0.2s;
+    font-weight: bold;
+    color: #495057;
+    cursor: pointer;
     line-height: 1;
 }
 
-.nav-arrow-btn:hover:not(:disabled) {
+.navigation-controls .nav-arrow-btn:hover:not(:disabled) {
     background: #e9ecef;
     border-color: #adb5bd;
     color: #343a40;
     transform: scale(1.05);
 }
 
-.nav-arrow-btn:active:not(:disabled) {
+.navigation-controls .nav-arrow-btn:active:not(:disabled) {
     transform: scale(0.95);
 }
 
-.nav-arrow-btn:disabled {
+.navigation-controls .nav-arrow-btn:disabled {
     background: #f8f9fa;
     border-color: #e9ecef;
     color: #ced4da;

--- a/styles/main.css
+++ b/styles/main.css
@@ -463,6 +463,96 @@ section h2, .login-section h2 {
     border: 1px solid #dee2e6;
 }
 
+/* Guru Color Dropdown Styles */
+/* Guru Color Trigger (clickable area for dropdown) */
+.guru-color-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    padding: 4px 10px;
+    border-radius: 6px;
+    border: 1px solid #dee2e6;
+    background: #f8f9fa;
+    color: #2c3e50;
+    font-weight: 500;
+    transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
+    position: relative;
+}
+
+.guru-color-trigger:hover, .guru-color-trigger:focus {
+    background: #e3f2fd;
+    border-color: #90caf9;
+    box-shadow: 0 2px 8px rgba(33, 150, 243, 0.08);
+    outline: none;
+}
+
+.guru-color-dropdown {
+    top: 100%;
+    left: 0;
+    min-width: 140px;
+    background: white;
+    border: 1px solid #dee2e6;
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-8px);
+    transition: all 0.2s ease;
+}
+
+.guru-color-dropdown.show {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.guru-color-option {
+    padding: 8px 12px;
+    cursor: pointer;
+    border-bottom: 1px solid #f8f9fa;
+    transition: background-color 0.2s ease;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.guru-color-option:last-child {
+    border-bottom: none;
+    border-radius: 0 0 6px 6px;
+}
+
+.guru-color-option:first-child {
+    border-radius: 6px 6px 0 0;
+}
+
+.guru-color-option:hover {
+    background-color: #f8f9fa;
+}
+
+.guru-color-option.current {
+    background-color: #e3f2fd;
+    font-weight: 500;
+}
+
+.guru-color-indicator {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.guru-color-indicator.red {
+    background-color: #dc3545;
+}
+.guru-color-indicator.blue {
+    background-color: #007bff;
+}
+.guru-color-indicator.green {
+    background-color: #28a745;
+}
+
 .editor-controls {
     display: flex;
     gap: 10px;

--- a/styles/main.css
+++ b/styles/main.css
@@ -570,6 +570,76 @@ section h2, .login-section h2 {
     gap: 10px;
 }
 
+/* Match Table Modal Styles */
+.match-table-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0,0,0,0.45);
+    z-index: 2000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.match-table-modal {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.25);
+    max-width: 90vw;
+    width: 900px;
+    max-height: 80vh;
+    overflow: auto;
+    padding: 32px 24px;
+    position: relative;
+}
+.match-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 1rem;
+    background: white;
+}
+.match-table th, .match-table td {
+    border-bottom: 1px solid #e0e0e0;
+    padding: 8px 12px;
+    text-align: left;
+}
+.match-table th {
+    background: #f5f7fa;
+    font-weight: 700;
+    color: #2c3e50;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+.match-table tr {
+    cursor: pointer;
+}
+.match-table tr.current-row {
+    background: #bbdefb;
+    font-weight: bold;
+}
+.match-table tr[data-row]:hover {
+    background: #e3f2fd;
+}
+.match-table td {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 25vw;
+}
+@media (max-width: 1000px) {
+    .match-table-modal {
+        width: 98vw;
+        padding: 10px 2vw;
+    }
+    .match-table th, .match-table td {
+        padding: 6px 4px;
+        font-size: 0.95em;
+    }
+}
+
 /* Fullscreen analysis mode */
 .fullscreen-analysis {
     position: fixed;

--- a/styles/main.css
+++ b/styles/main.css
@@ -1596,10 +1596,11 @@ section h2, .login-section h2 {
 
 /* Color Selection Screen */
 .color-selection-screen {
-    max-width: 600px;
     margin: 0 auto;
     text-align: center;
-    padding: 40px 20px;
+    padding: 20px 20px;
+    max-height: 100vh;
+    overflow-y: auto;
 }
 
 .color-selection-screen h3 {

--- a/styles/main.css
+++ b/styles/main.css
@@ -806,10 +806,59 @@ section h2, .login-section h2 {
     border: 2px solid #fdcb6e;
 }
 
-.discrepancy-header {
+.discrepancy-header,
+.outcome-header {
     font-weight: bold;
     margin-bottom: 0;
     font-size: 1.1em;
+}
+
+/* Analysis content with current + other gurus */
+.analysis-content {
+    color: #2c3e50;
+    background: #f8f9fa;
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 2px solid #dee2e6;
+    margin-bottom: 8px;
+}
+
+.current-analysis {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 2px solid;
+    font-weight: 600;
+    min-height: 60px;
+    text-align: center;
+    margin-bottom: 8px;
+}
+
+.current-analysis.win {
+    background: #28a745;
+    color: white;
+    border-color: #155724;
+}
+
+.current-analysis.tie {
+    background: #ffc107;
+    color: #212529;
+    border-color: #856404;
+}
+
+.current-analysis.loss {
+    background: #dc3545;
+    color: white;
+    border-color: #721c24;
+}
+
+.current-analysis.other {
+    background: #007bff;
+    color: white;
+    border-color: #0056b3;
 }
 
 .other-analyses {
@@ -880,6 +929,52 @@ section h2, .login-section h2 {
     .other-analysis {
         min-width: auto;
     }
+}
+
+/* New list-style analysis display */
+.analysis-list {
+    padding: 8px 0;
+}
+
+.guru-analyses-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: 0.95em;
+}
+
+.guru-analysis-item {
+    display: flex;
+    align-items: center;
+    padding: 4px 0;
+    margin: 2px 0;
+}
+
+.guru-analysis-label {
+    font-weight: 700;
+    margin-right: 8px;
+    min-width: 45px;
+    color: #495057;
+}
+
+.analysis-result {
+    font-weight: 600;
+}
+
+.analysis-result.win {
+    color: #28a745;
+}
+
+.analysis-result.tie {
+    color: #ffc107;
+}
+
+.analysis-result.loss {
+    color: #dc3545;
+}
+
+.analysis-result.other {
+    color: #6c757d;
 }
 
 .scoring-buttons {


### PR DESCRIPTION
Asked copilot to do the writeup and it managed to catch all the little changes and none of the big ones. See its output below.

## Big new things
- Claim matches from the app! No need to open the sheet at all (well, except to edit deck notes and clocks, that will come later).
- Claim a single match or all matches for the same deck.
- Guru colour selector, when opening a new pod you haven't gurued yet.
- Guru colour change, clicking on your current colour lets you switch to a different one.
- Table of matches, showing you which ones have been claimed and letting you jump to your favourite spot.
- Discrepancies button to quickly find how many you have and get there to fix them.
- Improved requests to spreadsheet to be lighter and faster.


This is still only available to test users but it is looking good, hopefully it will be public by next month.

---------------------------------------

## Copilot's summary

This pull request updates the documentation and user interface to better reflect the workflow and logic for analysing 3 Card Blind MTG matches, simplifies the development and validation instructions, and introduces several UI improvements for guru color selection and match navigation. It also removes some unused or redundant code and parameters, streamlining both the codebase and the contributor experience.

**Documentation and Workflow Updates:**

* Rewrote `.github/copilot-instructions.md` to clarify application logic for 3 Card Blind matches, streamline validation and performance instructions, and add a clear workflow for making code changes. Removed redundant server and validation steps, and updated state management to use Google appData instead of localStorage. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L6-R8) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L22-L33) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L72-R71) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L102-R91)
* Updated the README to use British spelling ("Analyse Matches") for consistency with the application's terminology.

**User Interface Improvements:**

* Added a persistent `.status-message` div to the main content area for displaying status and feedback messages to the user. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R34) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L85)
* Enhanced the match analysis interface with a guru color selector dropdown, and added "Next" and "Next Discrepancy" buttons for improved navigation between matches and discrepancies.

**Codebase Simplification and Bug Fixes:**

* Removed the unused `guruSignature` parameter from `GoogleSheetsAPI.getSheetData` and all related calls, simplifying the data retrieval interface. [[1]](diffhunk://#diff-431e5adb210d9982cdf7bacdacad1bab1cd70c57028cb41316d8bb79d2d8b046L260-R255) [[2]](diffhunk://#diff-5f607b8c113eef877770912c085b68e1c2a5e93237a2a6dffa7072610cbb24a9L6-R6)
* Improved status messages to reflect the total number of rows available for analysis, and updated language for clarity and consistency (e.g., "analyse" instead of "analyze"). [[1]](diffhunk://#diff-431e5adb210d9982cdf7bacdacad1bab1cd70c57028cb41316d8bb79d2d8b046L273-R269) [[2]](diffhunk://#diff-431e5adb210d9982cdf7bacdacad1bab1cd70c57028cb41316d8bb79d2d8b046L298-R295) [[3]](diffhunk://#diff-431e5adb210d9982cdf7bacdacad1bab1cd70c57028cb41316d8bb79d2d8b046L322-R311)
* Removed an unused event listener for `refreshAnalysis` in `js/main.js`.